### PR TITLE
Corrige adicao duplicada

### DIFF
--- a/app/models/cart_item.rb
+++ b/app/models/cart_item.rb
@@ -3,4 +3,5 @@ class CartItem < ApplicationRecord
 	belongs_to :product
 
 	validates :quantity, numericality: { greater_than: 0 }, presence: true
+	validates :product_id, uniqueness: { scope: :cart_id, message: "already exists in cart" }
 end

--- a/spec/models/cart_items_spec.rb
+++ b/spec/models/cart_items_spec.rb
@@ -27,6 +27,16 @@ RSpec.describe CartItem, type: :model do
 				expect(cart_item.errors[:quantity]).to include("must be greater than 0")
 			end
 		end
+
+		it 'validates product id uniqueness' do
+			cart_item = CartItem.new(cart: cart, product: product, quantity: 1)
+			cart_item.save
+
+			cart_item2 = CartItem.new(cart: cart, product: product, quantity: 1)
+
+			expect(cart_item2.valid?).to be_falsey
+			expect(cart_item2.errors[:product_id]).to include("already exists in cart")
+		end
 	end
 
 	describe 'associations' do

--- a/spec/requests/carts_spec.rb
+++ b/spec/requests/carts_spec.rb
@@ -78,6 +78,20 @@ RSpec.describe "/carts", type: :request do
           expect(parsed_body).to eq(expected_response)
           expect(response).to have_http_status(:ok)
         end
+
+        context 'and is trying to add the same product' do
+          it 'returns error info in json format with status code 422' do
+            post '/cart', params: params
+            valid_session_cookie = response.headers['Set-Cookie']
+            cart_created_from_prev_session = Cart.last
+
+            post '/cart', params: params, headers: headers.merge('Cookie': valid_session_cookie)
+
+            parsed_body = JSON.parse(response.body, symbolize_names: true)
+            expect(parsed_body).to eq({ "errors": ["Product already exists in cart"] })
+            expect(response).to have_http_status(:unprocessable_entity)
+          end
+        end
       end
 
       context 'when the cart does not exist' do

--- a/spec/services/cart_manager_service_spec.rb
+++ b/spec/services/cart_manager_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe CartManagerService, type: :model do
 			let!(:previous_cart) { Cart.create(total_price: 0.0) }
 			let(:product) { Product.create(name: "Test Product", price: 10.0) }
 			let(:product2) { Product.create(name: "Test Product2", price: 7.0) }
-			let!(:cart_item0) { CartItem.create(cart: previous_cart, product: product, quantity: quantity) }
+			let!(:cart_item) { CartItem.create(cart: previous_cart, product: product, quantity: quantity) }
 			let(:quantity) { 1 }
 			let(:cart_params) {
 				{
@@ -29,7 +29,22 @@ RSpec.describe CartManagerService, type: :model do
 				expect { 
 					described_class.call(session: session, cart_params: cart_params)
 				}.not_to change(Cart, :count)
-			end	
+			end
+
+			context 'product already in cart' do
+				let(:cart_params) {
+					{
+						"product_id": product.id,
+						"quantity": quantity
+					}
+				}
+				
+				it 'raise an error' do
+					expect { 
+						described_class.call(session: session, cart_params: cart_params) 
+					}.to raise_error(ActiveRecord::RecordInvalid)
+				end
+			end
 
 			context 'invalid cart params' do
 				let(:cart_params) {


### PR DESCRIPTION
# Problem

O carrinho permite a entrada de um mesmo item, gerando itens duplicados.

# Solution

- Cria uma validação no model intermediário.

# Testing

## Setup

1 - Fetch da branch.
2 - Docker instalado no sistema.
3 - Software postman ou derivados instalado para requisições.

## Main scenarios

### Scenario 1: Sucesso

Realize um POST para [docker_ip]:3000/cart com os parametros "product_id" e "quantity":

```
{
  "product_id": 345, // id do produto sendo adicionado
  "quantity": 2, // quantidade de produto a ser adicionado
}

```
Realize um novo POST para [docker_ip]:3000/cart com os mesmos parametros "product_id" e "quantity":

```
{
  "product_id": 345, // id do produto sendo adicionado
  "quantity": 2, // quantidade de produto a ser adicionado
}
```

A saída deve informar o erro:

```
{
    "errors": [
        "Product already exists in cart"
    ]
}
```

